### PR TITLE
Fixing graphql queries in index.js and talk.js

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,7 +50,9 @@ const IndexPage = ({ data }) => (
 
 export const pageQuery = graphql`
   query IndexQuery {
-    allMarkdownRemark {
+    allMarkdownRemark(
+      filter: { fileAbsolutePath: { regex: "/talks/" } }
+    ) {
       edges {
         node {
           id

--- a/src/templates/talk.js
+++ b/src/templates/talk.js
@@ -42,7 +42,7 @@ export const talkQuery = graphql`
       frontmatter {
         path
         title
-        day
+        day(formatString: "D MMMM", locale: "pt-PT")
         place
         start_time
         end_time


### PR DESCRIPTION
Adding a filter to talks query in index.js so no other files show up on the list, and formatting date on a talk page to be more readable. 