### PR TITLE
Use div instead of p with dangerouslySetInnerHTML

### DIFF
--- a/src/components/program/CommonEvent.js
+++ b/src/components/program/CommonEvent.js
@@ -15,45 +15,45 @@ const CommonEvent = ({ color, event }) => {
     frontmatter: { title, path, speakers, start_time, end_time, place, type },
   } = event
   const [showAll, setShowAll] = useState(false)
-  return type === "Placeholder" ?
-    <SimpleEvent event={event.frontmatter} /> :
-    (
-      <div
-        data-date={start_time}
-        className={[eventsStyles.commonEvent, eventsStyles.main].join(" ")}
-      >
-        <DescriptionToggler
-          id={`toggleShowAll-${title}`}
-          showAll={showAll}
-          setShowAll={setShowAll}
-          backgroundColor={color}
-        />
-        <div>
-          <h3 className={eventsStyles.title}>
-            <Link style={{ color }} to={path}>
-              {path.includes("workshops") && "Workshop: "}{" "}
-              <span
-                className={
-                  !path.match(/sessions|visits/)
-                    ? eventsStyles.eventTitle
-                    : undefined
-                }
-              >
-                {title}
-              </span>
-            </Link>
-          </h3>
-          {speakers && <Speakers speakers={speakers} path={path} />}
-          <TimePlace start_time={start_time} end_time={end_time} place={place} />
-          <Collapse isOpen={showAll}>
-            <p
-              className={eventsStyles.description}
-              dangerouslySetInnerHTML={{ __html: html }}
-            ></p>
-          </Collapse>
-        </div>
+  return type === "Placeholder" ? (
+    <SimpleEvent event={event.frontmatter} />
+  ) : (
+    <div
+      data-date={start_time}
+      className={[eventsStyles.commonEvent, eventsStyles.main].join(" ")}
+    >
+      <DescriptionToggler
+        id={`toggleShowAll-${title}`}
+        showAll={showAll}
+        setShowAll={setShowAll}
+        backgroundColor={color}
+      />
+      <div>
+        <h3 className={eventsStyles.title}>
+          <Link style={{ color }} to={path}>
+            {path.includes("workshops") && "Workshop: "}{" "}
+            <span
+              className={
+                !path.match(/sessions|visits/)
+                  ? eventsStyles.eventTitle
+                  : undefined
+              }
+            >
+              {title}
+            </span>
+          </Link>
+        </h3>
+        {speakers && <Speakers speakers={speakers} path={path} />}
+        <TimePlace start_time={start_time} end_time={end_time} place={place} />
+        <Collapse isOpen={showAll}>
+          <div
+            className={eventsStyles.description}
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </Collapse>
       </div>
-    )
+    </div>
+  )
 }
 
 export default CommonEvent


### PR DESCRIPTION
There is a bug that ocasionally happens where the description toggler on the program page won't work, i.e it expands but shows nothing. Once again it happened to me, so I made a bit of research and found [this](https://github.com/gatsbyjs/gatsby/issues/11108). Basically, it seems that using `div` instead of `p` will prevent this issue from happening. I tested the production build locally and it worked.